### PR TITLE
eval_plotting_node - Add import for Axes3D

### DIFF
--- a/active_3d_planning_app_reconstruction/src/experiments/eval_plotting_node.py
+++ b/active_3d_planning_app_reconstruction/src/experiments/eval_plotting_node.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 # Plotting
 from matplotlib import pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
 from std_srvs.srv import Empty
 
 


### PR DESCRIPTION
`eval_plotting_node` throws an error with some versions of matplotlib when creating the 3D histogram plot, due to https://github.com/ethz-asl/mav_active_3d_planning/blob/f5bb38249273efb039f250997ae3e90f95884679/active_3d_planning_app_reconstruction/src/experiments/eval_plotting_node.py#L619

Adding an explicit import for Axes3D fixes the issue.