### PR TITLE
Added missing return statements

### DIFF
--- a/active_3d_planning_core/src/module/trajectory_evaluator/continuous_yaw_planning_evaluator.cpp
+++ b/active_3d_planning_core/src/module/trajectory_evaluator/continuous_yaw_planning_evaluator.cpp
@@ -42,6 +42,7 @@ namespace active_3d_planning {
             YawPlanningEvaluator::computeGain(traj_in);
             // find best stored yaw and apply it
             setBestYaw(traj_in);
+            return true;
         }
 
         bool ContinuousYawPlanningEvaluator::updateSegment(TrajectorySegment *segment) {

--- a/active_3d_planning_core/src/module/trajectory_generator/rrt.cpp
+++ b/active_3d_planning_core/src/module/trajectory_generator/rrt.cpp
@@ -225,6 +225,7 @@ namespace active_3d_planning {
                     return true;
                 }
             }
+            return false;
         }
 
         bool RRT::connectPoses(const EigenTrajectoryPoint &start,

--- a/active_3d_planning_core/src/module/trajectory_generator/rrt_star.cpp
+++ b/active_3d_planning_core/src/module/trajectory_generator/rrt_star.cpp
@@ -72,7 +72,7 @@ namespace active_3d_planning {
                     }
                 }
             }
-            RRT::selectSegment(result, root);
+            return RRT::selectSegment(result, root);
         }
 
         bool RRTStar::expandSegment(TrajectorySegment *target,


### PR DESCRIPTION
Some functions that should return booleans are missing return statements, causing segmentation faults. These are the ones I found to get the `RRTStar` trajectory generator with the `ContinuousYawPlanningEvaluator` following evaluator working. There can be more missing return statements I presume.