### PR TITLE
Changed to C++14 to fix PCL 1.10 problems

### DIFF
--- a/active_3d_planning_app_reconstruction/CMakeLists.txt
+++ b/active_3d_planning_app_reconstruction/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 catkin_package()
 

--- a/active_3d_planning_voxblox/CMakeLists.txt
+++ b/active_3d_planning_voxblox/CMakeLists.txt
@@ -4,7 +4,7 @@ project(active_3d_planning_voxblox)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 catkin_package()
 


### PR DESCRIPTION
To get this to compile on Ubuntu 20.04 for ROS Noetic I had to change to C++14; otherwise, there were a bunch of PCL-related problems. It is also mentioned in the [PCL 1.10 release notes](https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.10.0) that they default to C++14 now.