### PR TITLE
Removed '/' prefix from frame_id

### DIFF
--- a/active_3d_planning_ros/src/planner/ros_planner.cpp
+++ b/active_3d_planning_ros/src/planner/ros_planner.cpp
@@ -160,7 +160,7 @@ namespace active_3d_planning {
             visualization_msgs::MarkerArray msg;
             visualizationMarkersToMsg(markers, &msg);
             for (visualization_msgs::Marker &m : msg.markers) {
-                m.header.frame_id = "/world";
+                m.header.frame_id = "world";
                 m.header.stamp = ::ros::Time::now();
             }
             // check overwrite flag (for full array)
@@ -179,7 +179,7 @@ namespace active_3d_planning {
                     for (int i = markers.getMarkers().size(); i < count; ++i) {
                         // publish empty marker to remove previous ids
                         auto empty_marker = visualization_msgs::Marker();
-                        empty_marker.header.frame_id = "/world";
+                        empty_marker.header.frame_id = "world";
                         empty_marker.header.stamp = ::ros::Time::now();
                         empty_marker.type = visualization_msgs::Marker::POINTS;
                         empty_marker.id = i;


### PR DESCRIPTION
As stated in the [TF2 Migration page](http://wiki.ros.org/tf2/Migration#Removal_of_support_for_tf_prefix), it is no longer valid for a frame_id to start with a '/'. I removed them since otherwise it would not work with ROS Noetic.