### PR TITLE
Made sure occupied voxels are always added

### DIFF
--- a/active_3d_planning_core/src/module/sensor_model/iterative_ray_caster.cpp
+++ b/active_3d_planning_core/src/module/sensor_model/iterative_ray_caster.cpp
@@ -78,6 +78,11 @@ bool IterativeRayCaster::getVisibleVoxels(
           current_position = position + distance * direction;
           distance += p_ray_step_;
 
+          // Add point (duplicates are handled in
+          // CameraModel::getVisibleVoxelsFromTrajectory)
+          map_->getVoxelCenter(&voxel_center, current_position);
+          result->push_back(voxel_center);
+
           // Check voxel occupied
           if (map_->getVoxelState(current_position) ==
               map::OccupancyMap::OCCUPIED) {
@@ -86,11 +91,6 @@ bool IterativeRayCaster::getVisibleVoxels(
             cast_ray = false;
             break;
           }
-
-          // Add point (duplicates are handled in
-          // CameraModel::getVisibleVoxelsFromTrajectory)
-          map_->getVoxelCenter(&voxel_center, current_position);
-          result->push_back(voxel_center);
         }
         if (cast_ray) {
           current_segment++;

--- a/active_3d_planning_core/src/module/sensor_model/iterative_ray_caster_lidar.cpp
+++ b/active_3d_planning_core/src/module/sensor_model/iterative_ray_caster_lidar.cpp
@@ -78,6 +78,11 @@ bool IterativeRayCasterLidar::getVisibleVoxels(
           current_position = position + distance * direction;
           distance += p_ray_step_;
 
+          // Add point (duplicates are handled in
+          // CameraModel::getVisibleVoxelsFromTrajectory)
+          map_->getVoxelCenter(&voxel_center, current_position);
+          result->push_back(voxel_center);
+
           // Check voxel occupied
           if (map_->getVoxelState(current_position) ==
               map::OccupancyMap::OCCUPIED) {
@@ -86,11 +91,6 @@ bool IterativeRayCasterLidar::getVisibleVoxels(
             cast_ray = false;
             break;
           }
-
-          // Add point (duplicates are handled in
-          // CameraModel::getVisibleVoxelsFromTrajectory)
-          map_->getVoxelCenter(&voxel_center, current_position);
-          result->push_back(voxel_center);
         }
         if (cast_ray) {
           current_segment++;


### PR DESCRIPTION
Changed the implementation of raycaster and raycaster lidar to always include voxels on surfaces.

Currently, some points on the surface are not correctly added.