### PR TITLE
fixed planner crash due to missing return

### DIFF
--- a/active_3d_planning_core/src/module/trajectory_generator/rrt.cpp
+++ b/active_3d_planning_core/src/module/trajectory_generator/rrt.cpp
@@ -317,6 +317,7 @@ bool RRT::resetTree(TrajectorySegment* root) {
   }
   kdtree_ = std::unique_ptr<KDTree>(new KDTree(3, tree_data_));
   kdtree_->addPoints(0, tree_data_.points.size() - 1);
+  return true;
 }
 
 void RRT::TreeData::clear() {


### PR DESCRIPTION
RRT Planner crashes during launch due to undefined behavior arising from missing return statement. A return statement is added to fix the issue.