### PR TITLE
Add build test CI using github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,58 @@
+
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install catkin-tools on melodic
+      if: ${{ matrix.config.container == 'ros:melodic-ros-base-bionic' }}
+      run: |
+        apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        apt update && apt install -y python3-wstool python-catkin-tools 
+    - name: Install catkin-tools on Noetic
+      if: ${{ matrix.config.container == 'ros:noetic-ros-base-focal' }}
+      run: |
+        apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        apt update && apt install -y python3-pip
+        pip3 install osrf-pycommon
+        apt update && apt install -y python3-wstool python3-catkin-tools
+    - name: release_build_test
+      working-directory: 
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt update
+        apt install -y python3-wstool autoconf libtool git
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        wstool init src src/mav_active_3d_planning/mav_active_3d_planning_https.rosinstall
+        wstool update -t src -j4
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+        catkin build -j$(nproc) -l$(nproc) mav_active_3d_planning

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
-          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+          # - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
-          # - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Packages and their dependencies:
 
 * **app_reconstruction:**
 
-   Application package for autonomous 3D reconstruction with MAVs, including automated simulation and evaluation routines. Dependencies:
+   Application package for autonomous 3D reconstruction with MAVs, including automated simulation and evaluation routines. 
+   In order to enable simulations uncomment the dependencies in these [lines](https://github.com/ethz-asl/mav_active_3d_planning/blob/46143ae558c3d62fa2673a43cbfdd22fb6de12a9/mav_active_3d_planning/package.xml#L13-L17)
+   Dependencies:
     * `unreal_cv_ros` ([https://github.com/ethz-asl/unreal_cv_ros](https://github.com/ethz-asl/unreal_cv_ros))
     * `rotors_simulator` ([https://github.com/ethz-asl/rotors_simulator](https://github.com/ethz-asl/rotors_simulator))
     * `mav_control_rw` ([https://github.com/ethz-asl/mav_control_rw](https://github.com/ethz-asl/mav_control_rw))

--- a/active_3d_planning_app_reconstruction/package.xml
+++ b/active_3d_planning_app_reconstruction/package.xml
@@ -29,9 +29,9 @@
     <depend>nav_msgs</depend>
     
     <!-- Dependencies to run simulation -->
-    <exec_depend>>mav_nonlinear_mpc</exec_depend>
+    <!-- <exec_depend>>mav_nonlinear_mpc</exec_depend>
     <exec_depend>mav_lowlevel_attitude_controller</exec_depend>
     <exec_depend>rotors_gazebo</exec_depend>
     <exec_depend>rotors_description</exec_depend>
-    <exec_depend>unreal_cv_ros</exec_depend>
+    <exec_depend>unreal_cv_ros</exec_depend> -->
 </package>

--- a/active_3d_planning_app_reconstruction/package.xml
+++ b/active_3d_planning_app_reconstruction/package.xml
@@ -29,9 +29,9 @@
     <depend>nav_msgs</depend>
     
     <!-- Dependencies to run simulation -->
-    <depend>mav_nonlinear_mpc</depend>
-    <depend>mav_lowlevel_attitude_controller</depend>
-    <depend>rotors_gazebo</depend>
-    <depend>rotors_description</depend>
-    <depend>unreal_cv_ros</depend>
+    <exec_depend>>mav_nonlinear_mpc</exec_depend>
+    <exec_depend>mav_lowlevel_attitude_controller</exec_depend>
+    <exec_depend>rotors_gazebo</exec_depend>
+    <exec_depend>rotors_description</exec_depend>
+    <exec_depend>unreal_cv_ros</exec_depend>
 </package>

--- a/mav_active_3d_planning_https.rosinstall
+++ b/mav_active_3d_planning_https.rosinstall
@@ -18,3 +18,4 @@
 - git: {local-name: mavros, uri: 'https://github.com/ethz-asl/mavros.git'}
 - git: {local-name: catkin_boost_python_buildtool, uri: 'https://github.com/ethz-asl/catkin_boost_python_buildtool.git'}
 - git: {local-name: numpy_eigen, uri: 'https://github.com/ethz-asl/numpy_eigen.git'}
+- git: {local-name: catkin_grpc, uri: 'https://github.com/CogRob/catkin_grpc.git'}


### PR DESCRIPTION
**Problem Description**
This PR adds a build test CI for this repository using github actions.

This adds a nice sanity checks if the chain of catkin dependencies are being broken and if we need to start fixing dependency versions.

While adding the PR the following was added

- Simulation dependencies seems to be broken and ill configured for rosdep installations. Since they are also not part of the dependency list, I think it is more sensible to remove them by default from the `package.xml` and add them as optional. I have separated the commits to show that the dependencies are broken for the simulation
- `grpc` is a dependency of `protobuf_catkin` but was not part of the dependency list and was not getting pulled
- The build test runs both ROS Melodic(Ubuntu Bionic 18.04) and ROS Noetic(Ubuntu Focal 20.04), but Noetic fails due to voxblox not supporting ROS Noetic. This is due to pcl requiring `c++14` and higher and is being addressed in https://github.com/ethz-asl/voxblox/pull/379

Since the build is not automatically triggered in the `ethz-asl` organization from forks, you can see the build results in https://github.com/Jaeyoung-Lim/mav_active_3d_planning/pull/1

![image](https://user-images.githubusercontent.com/5248102/139241035-4b05694c-52ee-45eb-a137-637ce936fe0d.png)


**Additional Context**
- The build is configured to only be triggered by new merges and pull requests